### PR TITLE
Support pushing helm charts to other other helm repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 __pycache__
 *.tgz
+tmp/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 __pycache__
+*.tgz

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,15 @@ RUN wget https://download.docker.com/linux/static/stable/x86_64/docker-19.03.8.t
     && tar -xvf docker-19.03.8.tgz \
     && wget https://raw.githubusercontent.com/helm/helm/release-3.6.2/scripts/get-helm-3 -O get_helm.sh \
     && chmod 700 ./get_helm.sh \
-    && ./get_helm.sh \
-    && helm plugin install https://github.com/chartmuseum/helm-push.git
+    && ./get_helm.sh
 
 FROM python:3
 ENV HELM_EXPERIMENTAL_OCI=1
 WORKDIR /workdir
 COPY --from=builder /docker/docker /usr/local/bin/docker
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm
-RUN python3 -m pip install pyyaml
+RUN python3 -m pip install pyyaml \
+    && helm plugin install https://github.com/chartmuseum/helm-push.git
 
 ADD src/ /usr/local/bin/
 ENTRYPOINT ["helm_image_mirror.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM python:3 as builder
 RUN wget https://download.docker.com/linux/static/stable/x86_64/docker-19.03.8.tgz \
     && tar -xvf docker-19.03.8.tgz \
-    && wget https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 -O get_helm.sh \
+    && wget https://raw.githubusercontent.com/helm/helm/release-3.6.2/scripts/get-helm-3 -O get_helm.sh \
     && chmod 700 ./get_helm.sh \
-    && ./get_helm.sh
+    && ./get_helm.sh \
+    && helm plugin install https://github.com/chartmuseum/helm-push.git
 
 FROM python:3
+ENV HELM_EXPERIMENTAL_OCI=1
 WORKDIR /workdir
 COPY --from=builder /docker/docker /usr/local/bin/docker
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@ build:
 	bash -ex ./build.sh build
 
 run:
+	rm -rf tmp
 	mkdir -p tmp
 	bash -ex ./build.sh run $(CONFIG)
 
 test:
-	pytest
+	pytest -v
 
 .PHONY: build run test

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ build:
 	bash -ex ./build.sh build
 
 run:
+	mkdir -p tmp
 	bash -ex ./build.sh run $(CONFIG)
 
 test:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ registries:
     # (optional) images will not be pushed to the registry if set to false
     push: true
 
+repos:
+  - name: my-helm-repo
+    retain: false
+    push: true
 
 # init_scripts specifies any initilization scripts that must be run before starting the
 # program. This can be used to enhance the functionality that is not available natively.

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ function build() {
 
 function run() {
     DOCKER_SOCK=/var/run/docker.sock
-    docker run -it --rm -v $DOCKER_SOCK:$DOCKER_SOCK -v $PWD:/workdir $IMAGE -c "$CONFIG"
+    docker run -it --rm -v $DOCKER_SOCK:$DOCKER_SOCK -v $PWD:/workdir -v $PWD/tmp:/tmp $IMAGE -c "$CONFIG" --debug
 }
 
 $1 "$@"

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ function build() {
 
 function run() {
     DOCKER_SOCK=/var/run/docker.sock
-    docker run -it --rm -v $DOCKER_SOCK:$DOCKER_SOCK -v $PWD:/workdir -v $PWD/tmp:/tmp $IMAGE -c "$CONFIG" --debug
+    docker run -it --rm -v $DOCKER_SOCK:$DOCKER_SOCK -v $PWD:/workdir -v $PWD/tmp:/tmp $IMAGE -c "$CONFIG"
 }
 
 $1 "$@"

--- a/sample-config.yaml
+++ b/sample-config.yaml
@@ -21,8 +21,8 @@ charts:
     # (optional) overrides global fetch setting
     # from remote repository
     fetch: true
-    (optional) push specifies the list of target helm repositories to which
-    the chart should be pushed
+    # (optional) push specifies the list of target helm repositories to which
+    # the chart should be pushed
     push:
       - my_helm_repo
     # (optional) values to be passed to chart before rendering the templates

--- a/sample-config.yaml
+++ b/sample-config.yaml
@@ -21,6 +21,10 @@ charts:
     # (optional) overrides global fetch setting
     # from remote repository
     fetch: true
+    (optional) push specifies the list of target helm repositories to which
+    the chart should be pushed
+    push:
+      - my_helm_repo
     # (optional) values to be passed to chart before rendering the templates
     # can be used for charts that have mandatorily required values
     values:

--- a/src/helm_image_mirror.py
+++ b/src/helm_image_mirror.py
@@ -130,7 +130,8 @@ class Chart:
         return images
 
     def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+        return isinstance(other, self.__class__) and \
+            self.__dict__ == other.__dict__
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/src/helm_image_mirror.py
+++ b/src/helm_image_mirror.py
@@ -169,7 +169,8 @@ class Registry:
                 docker("push {}".format(target_name))
             except subprocess.CalledProcessError:
                 push_failures.add(target_name)
-            succeeded.add(target_name)
+            else:
+                succeeded.add(target_name)
             if not self.retain:
                 try:
                     docker("rmi {}".format(target_name))
@@ -665,6 +666,8 @@ def push_charts(charts, repos):
                 else:
                     msg = "Unable to push chart. {}".format(DEBUG_HELP_MSG)
                 stat["push"][repo_name] = msg
+            else:
+                stat["push"][repo_name] = "Pushed successfully"
     return status
     
 
@@ -728,7 +731,7 @@ def main(file):
     charts = get_charts(charts, global_fetch_policy=global_fetch_policy)
 
     # push charts to target helm repositories
-    chart_push_failures = push_charts(charts, repos)
+    chart_push_status = push_charts(charts, repos)
 
     # Retag and push images
     images = get_all_images(charts)
@@ -752,8 +755,9 @@ def main(file):
         }
     )
     print_dict(failures)
-    print("{:=^50}".format(" Chart Status "))
-    print_dict(chart_push_failures)
+    if chart_push_status:
+        print("{:=^50}".format(" Chart Status "))
+        print_dict(chart_push_status)
     print("{:=^50}".format(" Status "))
 
 

--- a/test/test_charts.py
+++ b/test/test_charts.py
@@ -21,6 +21,9 @@ charts:
     values:
       set: abc.xyz=1
       set_str: pqr.xyz=true
+    push:
+      - target1
+      - target2
     versions:
     - fetch: true
       local_dir: tc1
@@ -33,6 +36,8 @@ charts:
       version: 2.0.0
     - local_dir: tc3
       version: 3.0.0
+      push:
+        - target3
   # chart specific false
   - fetch: false
     repo: prod
@@ -66,9 +71,10 @@ def test_get_charts(global_fetch_policy):
     charts = get_charts(charts_config, global_fetch_policy)
     group1_values = {"set": "abc.xyz=1", "set_str": "pqr.xyz=true"}
     expected = [
-        Chart("stable", "redis", "1.0.0", "tc1", True, {"set": "abc.xyz=2", "set_str": "qwe.rty=false"}),
-        Chart("stable", "redis", "2.0.0", "tc2", False, group1_values),
-        Chart("stable", "redis", "3.0.0", "tc3", True, group1_values),
+        Chart("stable", "redis", "1.0.0", "tc1", True, 
+          {"set": "abc.xyz=2", "set_str": "qwe.rty=false"}, ['target1', 'target2']),
+        Chart("stable", "redis", "2.0.0", "tc2", False, group1_values, ['target1', 'target2']),
+        Chart("stable", "redis", "3.0.0", "tc3", True, group1_values, ['target3']),
         Chart("prod", "mongo", "4.0.0", "tc4", True),
         Chart("prod", "mongo", "5.0.0", "tc5", False),
         Chart("prod", "mongo", "6.0.0", "/tmp/prod/mongo/2", False),


### PR DESCRIPTION
Add `push` field under `charts` configuration which takes list of helm repositories to which the chart/chart version must be pushed. 